### PR TITLE
Add basic undo/redo functionality

### DIFF
--- a/src/shared/BookmarksModel.cpp
+++ b/src/shared/BookmarksModel.cpp
@@ -133,3 +133,11 @@ void BookmarksModel::erase(int frame) {
 
     endRemoveRows();
 }
+
+void BookmarksModel::clear() {
+    if (!size()) return;
+
+    beginRemoveRows(QModelIndex(), 0, size() - 1);
+    BookmarkMap::clear();
+    endRemoveRows();
+}

--- a/src/shared/BookmarksModel.h
+++ b/src/shared/BookmarksModel.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #include "WobblyTypes.h"
 
 
-class BookmarksModel : public QAbstractTableModel, private BookmarkMap {
+class BookmarksModel : public QAbstractTableModel, public BookmarkMap {
     Q_OBJECT
 
 public:
@@ -62,6 +62,8 @@ public:
     void insert(const value_type &bookmark);
 
     void erase(int frame);
+
+    void clear();
 };
 
 #endif // BOOKMARKSMODEL_H

--- a/src/shared/CombedFramesModel.h
+++ b/src/shared/CombedFramesModel.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #include <QAbstractListModel>
 
 
-class CombedFramesModel : public QAbstractListModel, private std::set<int> {
+class CombedFramesModel : public QAbstractListModel, public std::set<int> {
     Q_OBJECT
 
 public:

--- a/src/shared/CustomListsModel.cpp
+++ b/src/shared/CustomListsModel.cpp
@@ -105,6 +105,15 @@ void CustomListsModel::erase(int list_index) {
 }
 
 
+void CustomListsModel::clear() {
+    if (!size()) return;
+
+    beginRemoveRows(QModelIndex(), 0, size() - 1);
+    CustomListVector::clear();
+    endRemoveRows();
+}
+
+
 void CustomListsModel::moveCustomListUp(int list_index) {
     if (beginMoveRows(QModelIndex(), list_index, list_index, QModelIndex(), list_index - 1)) {
         std::swap(at(list_index - 1), at(list_index));

--- a/src/shared/CustomListsModel.h
+++ b/src/shared/CustomListsModel.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #include "WobblyTypes.h"
 
 
-class CustomListsModel : public QAbstractTableModel, private CustomListVector {
+class CustomListsModel : public QAbstractTableModel, public CustomListVector {
     Q_OBJECT
 
     enum Columns {
@@ -60,6 +60,8 @@ public:
     void push_back(const CustomList &cl);
 
     void erase(int list_index);
+
+    void clear();
 
     void moveCustomListUp(int list_index);
 

--- a/src/shared/FrameRangesModel.h
+++ b/src/shared/FrameRangesModel.h
@@ -30,7 +30,7 @@ struct FrameRange {
 };
 
 
-class FrameRangesModel : public QAbstractTableModel, private std::map<int, FrameRange> {
+class FrameRangesModel : public QAbstractTableModel, public std::map<int, FrameRange> {
     Q_OBJECT
 
     enum Columns {

--- a/src/shared/FrozenFramesModel.cpp
+++ b/src/shared/FrozenFramesModel.cpp
@@ -111,3 +111,11 @@ void FrozenFramesModel::erase(int freeze_frame) {
 
     endRemoveRows();
 }
+
+void FrozenFramesModel::clear() {
+    if (!size()) return;
+
+    beginRemoveRows(QModelIndex(), 0, size() - 1);
+    FreezeFrameMap::clear();
+    endRemoveRows();
+}

--- a/src/shared/FrozenFramesModel.h
+++ b/src/shared/FrozenFramesModel.h
@@ -28,7 +28,7 @@ SOFTWARE.
 #include "WobblyTypes.h"
 
 
-class FrozenFramesModel : public QAbstractTableModel, private FreezeFrameMap {
+class FrozenFramesModel : public QAbstractTableModel, public FreezeFrameMap {
     Q_OBJECT
 
     enum Columns {
@@ -57,6 +57,8 @@ public:
     void insert(const value_type &freeze_frame);
 
     void erase(int freeze_frame);
+
+    void clear();
 };
 
 #endif // FROZENFRAMESMODEL_H

--- a/src/shared/PresetsModel.cpp
+++ b/src/shared/PresetsModel.cpp
@@ -91,3 +91,11 @@ void PresetsModel::erase(const std::string &preset_name) {
 
     endRemoveRows();
 }
+
+void PresetsModel::clear() {
+    if (!size()) return;
+
+    beginRemoveRows(QModelIndex(), 0, size() - 1);
+    PresetMap::clear();
+    endRemoveRows();
+}

--- a/src/shared/PresetsModel.h
+++ b/src/shared/PresetsModel.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #include "WobblyTypes.h"
 
 
-class PresetsModel : public QAbstractListModel, private PresetMap {
+class PresetsModel : public QAbstractListModel, public PresetMap {
     Q_OBJECT
 
 public:
@@ -46,6 +46,8 @@ public:
     void insert(const value_type &preset);
 
     void erase(const std::string &preset_name);
+
+    void clear();
 };
 
 #endif // PRESETSMODEL_H

--- a/src/shared/SectionsModel.cpp
+++ b/src/shared/SectionsModel.cpp
@@ -117,6 +117,12 @@ void SectionsModel::erase(int section_start) {
     endRemoveRows();
 }
 
+void SectionsModel::clear() {
+    beginRemoveRows(QModelIndex(), 0, size());
+    SectionMap::clear();
+    endRemoveRows();
+}
+
 
 void SectionsModel::setSectionPresetName(int section_start, size_t preset_index, const std::string &preset_name) {
     SectionMap::iterator it = find(section_start);

--- a/src/shared/SectionsModel.h
+++ b/src/shared/SectionsModel.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #include "WobblyTypes.h"
 
 
-class SectionsModel : public QAbstractTableModel, private SectionMap {
+class SectionsModel : public QAbstractTableModel, public SectionMap {
     Q_OBJECT
 
 public:
@@ -54,6 +54,8 @@ public:
     void insert(const value_type &section);
 
     void erase(int section_start);
+
+    void clear();
 
     void setSectionPresetName(int section_start, size_t preset_index, const std::string &preset_name);
 

--- a/src/wobbly/WobblyWindow.h
+++ b/src/wobbly/WobblyWindow.h
@@ -70,6 +70,8 @@ private:
 
     QMenu *recent_menu;
 
+    QAction *undo_action;
+    QAction *redo_action;
 
 
     // Widgets.
@@ -180,6 +182,7 @@ private:
     QCheckBox *settings_use_relative_paths_check;
     QComboBox *settings_colormatrix_combo;
     QSpinBox *settings_cache_spin;
+    SpinBox *settings_undo_steps_spin;
     QCheckBox *settings_print_details_check;
     QCheckBox *settings_bookmark_description_check;
     SpinBox *settings_num_thumbnails_spin;
@@ -459,6 +462,12 @@ public slots:
 
     void zoomIn();
     void zoomOut();
+
+    void undo();
+    void redo();
+    void commit(std::string message);
+    void updateUndoActions();
+    void updateAfterUndo();
 
     void vsLogPopup(int msgType, const QString &msg);
     void frameDone(void *framev, int n, bool preview_node, const QString &errorMsg);


### PR DESCRIPTION
This works by simply keeping backups the entire relevant state of the Wobbly project after each action and rolling back to such states on undo/redo. This is feasible since Wobbly's internal state is not very memory-intensive.

A drawback is that all list or table models have to be repopulated from scratch, so selections in dialogs are cleared on every undo/redo. This could be improved later on by saving the UI state before a rollback and restoring it after it is completed.

Fixes dubhater/Wobbly#15 .