### PR TITLE
Fix Macos shortcuts, add macos ci, add meson build system

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,40 @@
+name: Macos-latest
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: install deps
+      run: |
+        brew install qt@5 autoconf automake libtool vapoursynth llvm
+
+    - name: build
+      run: |
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/qt@5/lib/pkgconfig:$PKG_CONFIG_PATH"
+        export PATH="/opt/homebrew/opt/qt@5/bin:$PATH"
+        export CC=/opt/homebrew/opt/llvm/bin/clang
+        export CXX=/opt/homebrew/opt/llvm/bin/clang++
+        export PATH=/opt/homebrew/opt/llvm/bin:$PATH  
+        export CPATH=/usr/local/include:$CPATH
+        export LIBRARY_PATH=/usr/local/lib:$LIBRARY_PATH
+
+        ./autogen.sh
+        ./configure
+        make -j
+
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v4.4.3
+      with:
+        path: |
+          ./woobly
+          ./wibbly

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,3 @@ configure~
 wibbly.ini
 confdefs.h
 conftest.dir/
-
-.DS_Store
-wibbly
-wobbly

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ configure~
 wibbly.ini
 confdefs.h
 conftest.dir/
+
+.DS_Store
+wibbly
+wobbly

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ conftest.dir/
 .DS_Store
 wibbly
 wobbly
+
+.vscode/*

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,115 @@
+project('wibbly-wobbly', ['c', 'cpp'],
+    default_options : [
+        'cpp_std=c++23',
+        'c_std=c23',
+        'warning_level=2',
+        'buildtype=release',
+        'b_lto=true'
+    ]
+)
+
+add_project_arguments('-Wall', '-Wextra', '-Wshadow', language : ['c', 'cpp'])
+add_project_arguments('-DUNICODE', '-D_UNICODE', language : ['c', 'cpp'])
+
+inc = include_directories('src/shared', '.')
+
+qt5_dep = dependency('qt5', modules : ['Core', 'Gui', 'Widgets'])
+vsscript_dep = dependency('vapoursynth-script', required : true)
+
+if host_machine.system() == 'windows'
+  add_project_link_arguments('-mwindows', language : ['c', 'cpp'])
+endif
+
+qt5 = import('qt5')
+
+shared_moc_files = qt5.preprocess(
+  moc_headers : [
+    'src/shared/BookmarksModel.h',
+    'src/shared/CombedFramesModel.h',
+    'src/shared/CustomListsModel.h',
+    'src/shared/DockWidget.h',
+    'src/shared/FrameRangesModel.h',
+    'src/shared/FrozenFramesModel.h',
+    'src/shared/ListWidget.h',
+    'src/shared/PresetsModel.h',
+    'src/shared/ProgressDialog.h',
+    'src/shared/OrphanFieldsModel.h',
+    'src/shared/ScrollArea.h',
+    'src/shared/SectionsModel.h',
+    'src/shared/WobblyProject.h'
+  ]
+)
+
+wibbly_moc_files = qt5.preprocess(
+  moc_headers : [
+    'src/wibbly/WibblyWindow.h'
+  ]
+)
+
+wobbly_moc_files = qt5.preprocess(
+  moc_headers : [
+    'src/wobbly/CombedFramesCollector.h',
+    'src/wobbly/FrameLabel.h',
+    'src/wobbly/ImportWindow.h',
+    'src/wobbly/OverlayLabel.h',
+    'src/wobbly/PresetTextEdit.h',
+    'src/wobbly/SectionsProxyModel.h',
+    'src/wobbly/SpinBox.h',
+    'src/wobbly/TableView.h',
+    'src/wobbly/TableWidget.h',
+    'src/wobbly/WobblyWindow.h'
+  ]
+)
+
+rapidjson_inc = include_directories('.')
+
+shared_sources = [
+  'src/shared/BookmarksModel.cpp',
+  'src/shared/CombedFramesModel.cpp',
+  'src/shared/CustomListsModel.cpp',
+  'src/shared/DockWidget.cpp',
+  'src/shared/FrameRangesModel.cpp',
+  'src/shared/FrozenFramesModel.cpp',
+  'src/shared/ListWidget.cpp',
+  'src/shared/PresetsModel.cpp',
+  'src/shared/ProgressDialog.cpp',
+  'src/shared/OrphanFieldsModel.cpp',
+  'src/shared/ScrollArea.cpp',
+  'src/shared/SectionsModel.cpp',
+  'src/shared/WobblyProject.cpp',
+  'src/shared/WobblyShared.cpp'
+]
+
+wobbly_sources = [
+  'src/wobbly/CombedFramesCollector.cpp',
+  'src/wobbly/FrameLabel.cpp',
+  'src/wobbly/ImportWindow.cpp',
+  'src/wobbly/OverlayLabel.cpp',
+  'src/wobbly/PresetTextEdit.cpp',
+  'src/wobbly/SectionsProxyModel.cpp',
+  'src/wobbly/SpinBox.cpp',
+  'src/wobbly/TableView.cpp',
+  'src/wobbly/TableWidget.cpp',
+  'src/wobbly/Wobbly.cpp',
+  'src/wobbly/WobblyWindow.cpp'
+]
+
+wibbly_sources = [
+  'src/wibbly/Wibbly.cpp',
+  'src/wibbly/WibblyJob.cpp',
+  'src/wibbly/WibblyWindow.cpp'
+]
+
+executable('wobbly',
+  wobbly_sources + shared_sources + shared_moc_files + wobbly_moc_files,
+  include_directories : [inc, rapidjson_inc],
+  dependencies : [qt5_dep, vsscript_dep],
+  install : true
+)
+
+executable('wibbly',
+  wibbly_sources + shared_sources + shared_moc_files + wibbly_moc_files,
+  include_directories : [inc, rapidjson_inc],
+  dependencies : [qt5_dep, vsscript_dep],
+  install : true
+)

--- a/src/shared/WobblyShared.cpp
+++ b/src/shared/WobblyShared.cpp
@@ -34,7 +34,7 @@ SOFTWARE.
 #define VSSCRIPT_SO "vsscript.dll"
 #else
 #ifdef __APPLE__
-#define VSSCRIPT_SO "/opt/homebrew/lib/libvapoursynth-script.dylib"
+#define VSSCRIPT_SO "libvapoursynth-script.dylib"
 #define DLOPEN_FLAGS RTLD_LAZY | RTLD_GLOBAL
 #else
 #define VSSCRIPT_SO "libvapoursynth-script.so"

--- a/src/shared/WobblyShared.cpp
+++ b/src/shared/WobblyShared.cpp
@@ -34,7 +34,7 @@ SOFTWARE.
 #define VSSCRIPT_SO "vsscript.dll"
 #else
 #ifdef __APPLE__
-#define VSSCRIPT_SO "libvapoursynth-script.dylib"
+#define VSSCRIPT_SO "/opt/homebrew/lib/libvapoursynth-script.dylib"
 #define DLOPEN_FLAGS RTLD_LAZY | RTLD_GLOBAL
 #else
 #define VSSCRIPT_SO "libvapoursynth-script.so"

--- a/src/wobbly/WobblyWindow.cpp
+++ b/src/wobbly/WobblyWindow.cpp
@@ -525,8 +525,13 @@ void WobblyWindow::createShortcuts() {
         { "", "",                   "Set decimation pattern to range", &WobblyWindow::setDecimationPattern },
         { "", "",                   "Set match and decimation patterns to range", &WobblyWindow::setMatchAndDecimationPatterns },
         { "", "F5",                 "Toggle preview mode", &WobblyWindow::togglePreview },
+#ifdef __MACH__
+        { "", "Ctrl+=",         "Zoom in", &WobblyWindow::zoomIn },
+        { "", "Ctrl+-",         "Zoom out", &WobblyWindow::zoomOut },
+#else
         { "", "Ctrl+Num++",         "Zoom in", &WobblyWindow::zoomIn },
         { "", "Ctrl+Num+-",         "Zoom out", &WobblyWindow::zoomOut },
+#endif
         { "", "",                   "Guess current section's patterns from matches", &WobblyWindow::guessCurrentSectionPatternsFromMatches },
         { "", "",                   "Guess every section's patterns from matches", &WobblyWindow::guessProjectPatternsFromMatches },
         { "", "Ctrl+Alt+G",         "Guess current section's patterns from mics", &WobblyWindow::guessCurrentSectionPatternsFromMics },

--- a/src/wobbly/WobblyWindow.cpp
+++ b/src/wobbly/WobblyWindow.cpp
@@ -526,8 +526,8 @@ void WobblyWindow::createShortcuts() {
         { "", "",                   "Set match and decimation patterns to range", &WobblyWindow::setMatchAndDecimationPatterns },
         { "", "F5",                 "Toggle preview mode", &WobblyWindow::togglePreview },
 #ifdef __MACH__
-        { "", "Ctrl+=",         "Zoom in", &WobblyWindow::zoomIn },
-        { "", "Ctrl+-",         "Zoom out", &WobblyWindow::zoomOut },
+        { "", "Ctrl+=",             "Zoom in", &WobblyWindow::zoomIn },
+        { "", "Ctrl+-",             "Zoom out", &WobblyWindow::zoomOut },
 #else
         { "", "Ctrl+Num++",         "Zoom in", &WobblyWindow::zoomIn },
         { "", "Ctrl+Num+-",         "Zoom out", &WobblyWindow::zoomOut },


### PR DESCRIPTION
The shortcut `ctrl + Q` is changed to `ctrl + Backspace` because `ctrl + Q` quits the app on macos.
Also, shortcuts with arrow keys are fixed.