### PR TITLE
Fix compilation

### DIFF
--- a/src/shared/WobblyProject.cpp
+++ b/src/shared/WobblyProject.cpp
@@ -4132,12 +4132,7 @@ const char *WobblyProject::getArgsForSourceFilter() const {
 
 
 void WobblyProject::sourceToScript(std::string &script, bool save_node) const {
-    std::string src = std::format(
-        "src = c.{}(r'{}'{})\n",
-        source_filter,
-        handleSingleQuotes(input_file),
-        getArgsForSourceFilter()
-    );
+    std::string src = "src = c." + source_filter + "(r'" + handleSingleQuotes(input_file) + "'" + getArgsForSourceFilter() + ")\n";
 
     if (save_node) {
     script +=

--- a/src/wibbly/WibblyJob.cpp
+++ b/src/wibbly/WibblyJob.cpp
@@ -245,24 +245,20 @@ const char *WibblyJob::getArgsForSourceFilter() const {
 void WibblyJob::sourceToScript(std::string &script) const {
     std::string fixed_input_file = handleSingleQuotes(input_file);
 
-    script += std::format(
-            "if wibbly_last_input_file == r'{0}':\n"
+    script +=
+            "if wibbly_last_input_file == r'" + fixed_input_file + "':\n"
             "    try:\n"
             "        src = vs.get_output(index=1)\n"
             "        if isinstance(src, vs.VideoOutputTuple):\n"
             "            src = src[0]\n"
             "    except KeyError:\n"
-            "        src = c.{1}(r'{0}'{2})\n"
+            "        src = c." + source_filter + "(r'" + fixed_input_file + "'" + getArgsForSourceFilter() + ")\n"
             "        src.set_output(index=1)\n"
             "else:\n"
-            "    src = c.{1}(r'{0}'{2})\n"
+            "    src = c." + source_filter + "(r'" + fixed_input_file + "'" + getArgsForSourceFilter() + ")\n"
             "    src.set_output(index=1)\n"
-            "    wibbly_last_input_file = r'{0}'\n"
-            "\n",
-            fixed_input_file,
-            source_filter,
-            getArgsForSourceFilter()
-    );
+            "    wibbly_last_input_file = r'" + fixed_input_file + "'\n"
+            "\n";
 }
 
 


### PR DESCRIPTION
std::format was introduced in C++20 and there is no reason to bump the required compiler for the sake of these two lines of code. Build was broken since a9272a23d81385f0ff373cdc6b6b7a141888eefe