### PR TITLE
Drop debug message popups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Wobbly], [8], [https://github.com/Jaded-Encoding-Thaumaturgy/Wobbly/issues], [Wobbly], [https://github.com/Jaded-Encoding-Thaumaturgy/Wobbly])
+AC_INIT([Wobbly], [9], [https://github.com/Jaded-Encoding-Thaumaturgy/Wobbly/issues], [Wobbly], [https://github.com/Jaded-Encoding-Thaumaturgy/Wobbly])
 
 : ${CFLAGS=""}
 : ${CXXFLAGS=""}

--- a/src/wibbly/WibblyWindow.cpp
+++ b/src/wibbly/WibblyWindow.cpp
@@ -102,6 +102,9 @@ WibblyWindow::WibblyWindow()
 
 
 void VS_CC messageHandler(int msgType, const char *msg, void *userData) {
+    if (msgType == mtDebug)
+        return;
+
     WibblyWindow *window = (WibblyWindow *)userData;
 
     Qt::ConnectionType type;
@@ -132,8 +135,8 @@ void WibblyWindow::vsLogPopup(int msgType, const QString &msg) {
         message += "critical";
     } else if (msgType == mtWarning) {
         message += "warning";
-    } else if (msgType == mtDebug) {
-        message += "debug";
+    } else if (msgType == mtInformation) {
+        message += "information";
     } else {
         message += "unknown";
     }

--- a/src/wobbly/WobblyWindow.cpp
+++ b/src/wobbly/WobblyWindow.cpp
@@ -3257,6 +3257,9 @@ void WobblyWindow::createUI() {
 
 
 void VS_CC messageHandler(int msgType, const char *msg, void *userData) {
+    if (msgType == mtDebug)
+        return;
+
     WobblyWindow *window = (WobblyWindow *)userData;
 
     Qt::ConnectionType type;
@@ -3294,8 +3297,8 @@ void WobblyWindow::vsLogPopup(int msgType, const QString &msg) {
         message += "critical";
     } else if (msgType == mtWarning) {
         message += "warning";
-    } else if (msgType == mtDebug) {
-        message += "debug";
+    } else if (msgType == mtInformation) {
+        message += "information";
     } else {
         message += "unknown";
     }


### PR DESCRIPTION
Debug messages are too numerous/verbose. It’s the lowest level in VapourSynth’s logging system, so they’re not normally supposed to be seen.

This alleviates #46, but I think debug messages should be completely hidden by default even if #46 is implemented.