### PR TITLE
Fix interlaced fade list always missing the last fade

### DIFF
--- a/src/wobbly/WobblyWindow.cpp
+++ b/src/wobbly/WobblyWindow.cpp
@@ -3722,9 +3722,8 @@ void WobblyWindow::updateFadesWindow() {
         } else {
             end = it->first;
         }
-        if (it == (fades.cend()--))
-            fades_ranges.push_back({ start, end });
     }
+    fades_ranges.push_back({ start, end });
 
     fades_table->setRowCount(fades_ranges.size());
 


### PR DESCRIPTION
The last interlaced fade (if there are any in the project) was never shown in the UI.